### PR TITLE
Add jpg in screenshot filter

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -271,7 +271,7 @@ export const query = graphql`
         }
       }
     }
-    iphoneScreen: file(relativePath: { glob: "screenshot/*.png" }) {
+    iphoneScreen: file(relativePath: { glob: "screenshot/*.{png,jpg}" }) {
       childImageSharp {
         fluid(maxWidth: 350) {
           ...GatsbyImageSharpFluid


### PR DESCRIPTION
The screenshot states that it's possible to add a `.jpg` file. But it wasn't true.
Now I fixed it.