### PR TITLE
Fix broken drop shadow on app icon and download buttons

### DIFF
--- a/src/components/style.js
+++ b/src/components/style.js
@@ -201,7 +201,7 @@ export default createGlobalStyle`
 
   .appIconShadow {
     display: flex;
-    filter: drop-shadow(0px 5px 10px rgba(#000, 0.1)) drop-shadow(0px 1px 1px rgba(#000, 0.2));
+    filter: drop-shadow(0px 5px 10px rgba(0,0,0,0.1)) drop-shadow(0px 1px 1px rgba(0,0,0,0.2));
   }
 
   .appIconLarge {

--- a/src/components/style.js
+++ b/src/components/style.js
@@ -201,7 +201,7 @@ export default createGlobalStyle`
 
   .appIconShadow {
     display: flex;
-    filter: drop-shadow(0px 5px 10px rgba(0,0,0,0.1)) drop-shadow(0px 1px 1px rgba(0,0,0,0.2));
+    filter: drop-shadow(0px 5px 10px rgba(0, 0, 0, 0.1)) drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.2));
   }
 
   .appIconLarge {
@@ -272,7 +272,7 @@ export default createGlobalStyle`
   .downloadButtonsContainer {
     display: inline-block;
     margin-top: 42px;
-    filter: drop-shadow(0px 5px 10px rgba(#000, 0.1)) drop-shadow(0px 1px 1px rgba(#000, 0.2));
+    filter: drop-shadow(0px 5px 10px rgba(0, 0, 0, 0.1)) drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.2));
   }
 
   @media only screen and (max-width: 992px) {


### PR DESCRIPTION
Hey,

Thanks for the cool repo :) 

Currently the dropshadow for the app icon and download buttons are broken, as css doesnt support `rgba(hex, opacity)`, I guess that's a sass directive, and from the original repo. 

This PR updates that value to a valid one, so the shadow shows 👍 

